### PR TITLE
Add caching of /var/chef/cache and turn it on by default

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -6,8 +6,8 @@ default['chef-provisioning-vagrant']['vagrants_dir'] = ::File.join(Chef::Config[
 default['chef-provisioning-vagrant']['vendor_cookbooks_path'] = ::File.join(Chef::Config[:chef_repo_path], 'vendor')
 
 # machine details
-default['chef-provisioning-vagrant']['vbox']['box'] = 'opscode-ubuntu-14.04'
-default['chef-provisioning-vagrant']['vbox']['box_url'] = 'http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-14.04_chef-provisionerless.box'
+default['chef-provisioning-vagrant']['vbox']['box'] = 'bento/ubuntu-14.04'
+default['chef-provisioning-vagrant']['vbox']['box_url'] = nil
 default['chef-provisioning-vagrant']['vbox']['ram'] = 512
 default['chef-provisioning-vagrant']['vbox']['cpus'] = 1
 default['chef-provisioning-vagrant']['vbox']['chef_cache'] = true

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -10,6 +10,7 @@ default['chef-provisioning-vagrant']['vbox']['box'] = 'opscode-ubuntu-14.04'
 default['chef-provisioning-vagrant']['vbox']['box_url'] = 'http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-14.04_chef-provisionerless.box'
 default['chef-provisioning-vagrant']['vbox']['ram'] = 512
 default['chef-provisioning-vagrant']['vbox']['cpus'] = 1
+default['chef-provisioning-vagrant']['vbox']['chef_cache'] = true
 
 default['chef-provisioning-vagrant']['vbox']['private_networks'] = {}
 # provide a list of private network interfaces to provisioning

--- a/libraries/vagrant_config.rb
+++ b/libraries/vagrant_config.rb
@@ -64,6 +64,15 @@ module VagrantConfigHelper
       end
     end
 
+    if config[:chef_cache] == true || node['chef-provisioning-vagrant']['vbox']['chef_cache'] == true
+        vagrant_config += <<-ENDCONFIG
+    if Vagrant.has_plugin?("vagrant-cachier")
+      config.cache.scope = :box
+      config.cache.enable :generic, { :cache_dir => "/var/chef/cache" }
+    end
+        ENDCONFIG
+    end
+
     vagrant_config
   end
 end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -34,8 +34,8 @@ describe 'test::default' do
       expect(chef_run).to converge_machine('mario')
         .with(machine_options: {
           :vagrant_options => {
-            "vm.box" => "opscode-ubuntu-14.04",
-            "vm.box_url" => "http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-14.04_chef-provisionerless.box",
+            "vm.box" => "bento/ubuntu-14.04",
+            "vm.box_url" => nil,
             "vm.hostname" => "mario.example.com"
           },
           :vagrant_config=> <<-ENDCONFIG
@@ -76,8 +76,8 @@ it 'converges the machine with the correct machine_options' do
       expect(chef_run).to converge_machine('mario')
         .with(machine_options: {
           :vagrant_options => {
-            "vm.box" => "opscode-ubuntu-15.04",
-            "vm.box_url" => "http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-14.04_chef-provisionerless.box",
+            "vm.box" => "bento/ubuntu-16.04",
+            "vm.box_url" => nil,
             "vm.hostname" => "mario.example.com"
           },
           :vagrant_config=> <<-ENDCONFIG

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -50,6 +50,10 @@ describe 'test::default' do
         '--usbehci', 'off'
       ]
     end
+    if Vagrant.has_plugin?("vagrant-cachier")
+      config.cache.scope = :box
+      config.cache.enable :generic, { :cache_dir => "/var/chef/cache" }
+    end
           ENDCONFIG
         }
         )
@@ -90,6 +94,10 @@ it 'converges the machine with the correct machine_options' do
     end
     config.vm.network 'private_network', type: 'dhcp'
     config.vm.network 'private_network', ip: "33.33.33.10"
+    if Vagrant.has_plugin?("vagrant-cachier")
+      config.cache.scope = :box
+      config.cache.enable :generic, { :cache_dir => "/var/chef/cache" }
+    end
           ENDCONFIG
         }
         )

--- a/test/fixtures/cookbooks/test/recipes/advanced.rb
+++ b/test/fixtures/cookbooks/test/recipes/advanced.rb
@@ -3,7 +3,7 @@ include_recipe 'chef-provisioning-vagrant-helper::default'
 machine "mario" do
   recipe 'mario::default'
   machine_options vagrant_options("mario.example.com", config: {
-      box: 'opscode-ubuntu-15.04',
+      box: 'bento/ubuntu-16.04',
       ram: 1024,
       cpus: 2,
       private_networks: {


### PR DESCRIPTION
With the updates to `chef_ingredient` no longer creating apt/yum repos (which vagrant-cachier caches), I noticed my clusters taking a lot longer to create.

Even if you enable `:chef` caching globally in vagrant-cachier, that only works if it detects that the provisioner is Chef - which in the case of chef-provisioning-vagrant it is not.

So, the compromise is to create a generic cache bucket for `/var/chef/cache`.    However I'm a bit concerned about the `:box` scope so I'd love feedback on that. 
